### PR TITLE
changed GRIT path at the convert.sh scripts

### DIFF
--- a/graphics_manual/Levels/convert.sh
+++ b/graphics_manual/Levels/convert.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-GRIT=/opt/blocksds/core/tools/grit/grit
+GRIT=/opt/wonderful/thirdparty/blocksds/core/tools/grit/grit
 
 GRAPHICS=../../build/graphics/
 OUT=${GRAPHICS}/Levels/

--- a/graphics_manual/Menu/convert.sh
+++ b/graphics_manual/Menu/convert.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-GRIT=/opt/blocksds/core/tools/grit/grit
+GRIT=/opt/wonderful/thirdparty/blocksds/core/tools/grit/grit
 
 GRAPHICS=../../build/graphics/
 OUT=${GRAPHICS}/Menu/

--- a/graphics_manual/Misc/convert.sh
+++ b/graphics_manual/Misc/convert.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-GRIT=/opt/blocksds/core/tools/grit/grit
+GRIT=/opt/wonderful/thirdparty/blocksds/core/tools/grit/grit
 
 GRAPHICS=../../build/graphics/
 OUT=${GRAPHICS}/Misc/

--- a/graphics_manual/Splash/convert.sh
+++ b/graphics_manual/Splash/convert.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-GRIT=/opt/blocksds/core/tools/grit/grit
+GRIT=/opt/wonderful/thirdparty/blocksds/core/tools/grit/grit
 
 GRAPHICS=../../build/graphics/
 OUT=${GRAPHICS}/Splash/


### PR DESCRIPTION
While trying to build the project, i noticed that the path to GRIT at the bash scripts was 
``GRIT=/opt/blocksds/core/tools/grit/grit``
so i changed it to
``GRIT=/opt/wonderful/thirdparty/blocksds/core/tools/grit/grit``

That makes it work when using blocksds on windows through wonderful toolchains and msys2.

I don't know if this is an improvement or it works out of the box like it was before on other operating systems.

Thanks for reading me :)